### PR TITLE
Add 'multiple' args to overlap

### DIFF
--- a/pyranges/core/options.py
+++ b/pyranges/core/options.py
@@ -32,7 +32,7 @@ class PyRangesOptions:
         Examples
         --------
         >>> import pyranges as pr
-        >>> pr.options.set_option('max_rows_to_show', 10)
+        >>> pr.options.set_option('max_rows_to_show', 8)
 
 
         """

--- a/pyranges/core/tostring.py
+++ b/pyranges/core/tostring.py
@@ -174,19 +174,3 @@ def truncate_data(data: list[list[str]], max_col_width: int | None) -> list[list
                 new_row.append(item_str)
         truncated_data.append(new_row)
     return truncated_data
-
-
-# Define your data
-data = [
-    ["Alice", "Developer", "some very long text that might not fit on the screen", 30],
-    ["Bob", "Manager", "another very long piece of text", 27],
-]
-
-# Define headers
-headers = ["Name", "Occupation", "Description", "Age"]
-
-# Maximum width for any individual column
-max_col_width = 20
-
-# Maximum total width for the display
-max_total_width = 60  # For example, for a terminal width of 60 characters


### PR DESCRIPTION
- ensure that multiple='all' when using containment

- must use .loc instead of reindex since reindex does not support duplicates
  - and multiple='all' is likely to return duplicates

Piggiebacked:
  - in options unittest, ensure that we do not set the max_rows_to_show to another value
  - that might interfere with the __str__ unittest/doctest