### PR TITLE
overlap added invert, multiple now defaults to False, removed complem…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges1"
-version = "1.0.13"
+version = "1.0.14"
 description = "GenomicRanges for Python."
 requires-python = ">=3.12.0"
 readme = "README.md"


### PR DESCRIPTION
Dealing with https://github.com/pyranges/pyranges_1.x/issues/72 and https://github.com/pyranges/pyranges_1.x/issues/70

I reinstated two behaviors of overlap:
- not returning duplicated rows when multiple other intervals overlap by default; multiple=False default
- invert keyword reinstated; I removed complement_overlap which sounded like the very same thing

Still, ruranges.complement_overlap() does not offer contained_intervals_only functionality; and slack didn't behave as expected. Thus, when the user requests either of those things in combination with invert, I have a panda solution, likely slower. I think it's a rare usage case -- but there's always time to implement it later if we see fit