### PR TITLE
added native html for jupyter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges1"
-version = "1.1.2"
+version = "1.1.3"
 description = "GenomicRanges for Python."
 requires-python = ">=3.12.0"
 readme = "README.md"

--- a/pyranges/core/options.py
+++ b/pyranges/core/options.py
@@ -11,6 +11,11 @@ class PyRangesOptions:
                 "how many columns listed in PyRanges repr when not all fit the screen width",
             ),
             "console_width": (None, "console width, affecting PyRanges representation (None for auto)"),
+            "html_max_cols": (20, "max number of columns to show as HTML (e.g. Jupyter), others are hidden"),
+            "html_max_rows": (
+                None,
+                "max n. of rows shown as HTML (e.g. Jupyter). If undefined, max_rows_to_show is used",
+            ),
         }
         self.options_default = self.options_in_use.copy()
 
@@ -99,9 +104,11 @@ class PyRangesOptions:
         # the console width.
         >>> import pyranges as pr
         >>> print(pr.options.display_options())
-        max_rows_to_show         :   8 (the max number of rows to show in PyRanges repr)
-        max_column_names_to_show :   3 (how many columns listed in PyRanges repr when not all fit the screen width)
-        console_width            : 120 (console width, affecting PyRanges representation (None for auto))
+        max_rows_to_show         :    8 (the max number of rows to show in PyRanges repr)
+        max_column_names_to_show :    3 (how many columns listed in PyRanges repr when not all fit the screen width)
+        console_width            :  120 (console width, affecting PyRanges representation (None for auto))
+        html_max_cols            :   20 (max number of columns to show as HTML (e.g. Jupyter), others are hidden)
+        html_max_rows            : None (max n. of rows shown as HTML (e.g. Jupyter). If undefined, max_rows_to_show is used)
 
         """
         max_len_k = max(len(k) for k in self.options_in_use)

--- a/pyranges/range_frame/range_frame.py
+++ b/pyranges/range_frame/range_frame.py
@@ -24,7 +24,7 @@ from pyranges.core.names import (
     CombineIntervalColumnsOperation,
 )
 from pyranges.core.pyranges_helpers import arg_to_list, factorize, factorize_binary
-from pyranges.core.tostring import tostring
+from pyranges.core.tostring import tohtml, tostring
 from pyranges.methods.complement_overlaps import _complement_overlaps
 from pyranges.methods.join import _both_dfs
 from pyranges.methods.merge import _merge
@@ -71,6 +71,9 @@ class RangeFrame(pd.DataFrame):
 
     def __repr__(self, max_col_width: int | None = None, max_total_width: int | None = None) -> str:
         return self.__str__(max_col_width=max_col_width, max_total_width=max_total_width)
+
+    def _repr_html_(self) -> str:
+        return tohtml(self)
 
     def merge_overlaps(
         self,


### PR DESCRIPTION
addresses this
https://github.com/pyranges/pyranges_1.x/issues/99

Works for both RangeFrame and PyRanges
Some examples:

<img width="822" height="494" alt="Screenshot 2025-07-25 at 17 58 48" src="https://github.com/user-attachments/assets/af972b74-c3a0-4d63-9568-2f2ecf400fa4" />

<img width="662" height="527" alt="Screenshot 2025-07-25 at 17 59 43" src="https://github.com/user-attachments/assets/63a881a7-9973-413f-a0ef-1e8b79dbad0e" />

<img width="556" height="445" alt="Screenshot 2025-07-25 at 17 59 52" src="https://github.com/user-attachments/assets/1b885f21-6f91-42f7-9855-b485ba549e55" />

The pr.options determine how it is rendered. See logic:

```
max_rows_to_show         :    8 (the max number of rows to show in PyRanges repr)
max_column_names_to_show :    3 (how many columns listed in PyRanges repr when not all fit the screen width)
console_width            : None (console width, affecting PyRanges representation (None for auto))
html_max_cols            :   20 (max number of columns to show as HTML (e.g. Jupyter), others are hidden)
html_max_rows            : None (max n. of rows shown as HTML (e.g. Jupyter). If undefined, max_rows_to_show is used)
```

