### PR TITLE
fix: pyright astype overload + tox-gh env filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,11 @@ legacy_tox_ini = """
 [tox]
 envlist = py312, py313
 
+[gh]
+python =
+    3.12 = py312
+    3.13 = py313
+
 [testenv]
 basepython =
     py312: python3.12

--- a/pyranges1/methods/complement.py
+++ b/pyranges1/methods/complement.py
@@ -42,11 +42,7 @@ def _complement(
             the_chromsizes_col = the_chromsizes_col.astype(object)
 
         #  vectorised lookup with no FutureWarning
-        lengths = (
-            the_chromsizes_col.map(chromsizes).astype(  # faster/cleaner than replace
-                pos_dtype, copy=False
-            )  # ensure same dtype as starts/ends
-        )
+        lengths = the_chromsizes_col.map(chromsizes).astype(pos_dtype)  # faster/cleaner than replace
 
         group_to_len = pd.DataFrame(
             {


### PR DESCRIPTION
## Problem

The `check` CI has been failing on every scheduled run since ~2026-06-01 due to two independent issues.

## Fix 1 — `complement.py`: pyright `astype` overload error

`pandas-stubs` 3.x removed the `copy` parameter from `Series.astype` (pandas 3.0 dropped it at the API level). Pyright now reports:

```
pyranges1/methods/complement.py:45:19 - error: No overloads for "astype" match the provided arguments
  Argument types: (dtype[Any], Literal[False]) (reportCallIssue)
```

Fix: drop `copy=False` — pandas 3.x ignores it anyway and the dtype cast still happens correctly.

## Fix 2 — `pyproject.toml`: tox-gh runs all envs when `[gh]` section is absent

On the `3.12 ubuntu` matrix leg, tox ran both `py312` and `py313` instead of only `py312`. `py313` then failed immediately because Python 3.13 is not installed on a 3.12 runner. Adding the `[gh]` section tells tox-gh exactly which environment to activate for each Python version.

```ini
[gh]
python =
    3.12 = py312
    3.13 = py313
```

## Verified locally

```
pyright pyranges1/methods/complement.py
# 0 errors, 1 warning, 0 informations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)