### PR TITLE
Require ruranges 0.1.5 for correct complement_ranges attribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 keywords = ["bioinformatics", "genomicranges", "genomics"]
-dependencies = ["pandas", "tabulate", "natsort", "ruranges>=0.1.4", "gtfreader>=0.2.0"]
+dependencies = ["pandas", "tabulate", "natsort", "ruranges>=0.1.5", "gtfreader>=0.2.0"]
 
 [project.optional-dependencies]
 add-ons = [
@@ -104,7 +104,7 @@ deps =
     pyright == 1.1.406
     joblib
     gtfreader >= 0.2.0
-    ruranges >= 0.1.3
+    ruranges >= 0.1.5
     # fisher
 commands =
     pyright

--- a/pyranges1/_ruranges.py
+++ b/pyranges1/_ruranges.py
@@ -4,7 +4,7 @@ import re
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-MIN_RURANGES_VERSION = "0.1.3"
+MIN_RURANGES_VERSION = "0.1.5"
 
 
 def _version_tuple(v: str) -> tuple[int, ...]:

--- a/pyranges1/core/loci_getter.py
+++ b/pyranges1/core/loci_getter.py
@@ -69,8 +69,11 @@ def _rows_matching_strand(gr: "PyRanges", strand: str | None) -> "pd.Series[bool
 def _rows_matching_range(gr: "PyRanges", _range: slice | None) -> "pd.Series[bool]":
     if _range is None:
         return pd.Series(data=True, index=gr.index)
+    # An omitted bound leaves that side of the window open, so both use an
+    # infinite limit. A finite lower default such as -1 would silently drop
+    # intervals lying entirely below it.
     start_in_range = gr[START_COL] < (_range.stop if _range.stop is not None else np.inf)
-    end_in_range = gr[END_COL] > (_range.start if _range.start is not None else -1)
+    end_in_range = gr[END_COL] > (_range.start if _range.start is not None else -np.inf)
     return start_in_range & end_in_range
 
 

--- a/tests/unit/test_complement_ranges.py
+++ b/tests/unit/test_complement_ranges.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regression tests for gh-157.
+
+``complement_ranges`` used to label each gap with the group columns of an
+arbitrary row, so the reported ``Chromosome``/``Strand`` depended on the order
+of the input rows.
+"""
+
+import itertools
+
+import pandas as pd
+
+import pyranges1 as pr
+
+
+def _rows(gr, columns) -> list[tuple]:
+    return sorted(tuple(row) for row in gr[columns].to_numpy().tolist())
+
+
+def test_gaps_keep_their_own_chromosome_when_groups_are_not_in_ascending_order() -> None:
+    # ``chr2`` rows come first, so the group ids do not ascend with first
+    # appearance. Both gaps used to be reported on ``chr2``.
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr2", "chr2", "chr1", "chr1"],
+                "Start": [0, 20, 0, 10],
+                "End": [1, 21, 1, 11],
+            }
+        )
+    )
+
+    assert _rows(gr.complement_ranges(), ["Chromosome", "Start", "End"]) == [
+        ("chr1", 1, 10),
+        ("chr2", 1, 20),
+    ]
+
+
+def test_gap_is_labelled_with_the_strand_that_produced_it() -> None:
+    # The '-' strand holds a single interval and therefore has no internal gap;
+    # the only gap belongs to the '+' strand.
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr01", "chr01", "chr01"],
+                "Start": [0, 2, 0],
+                "End": [1, 3, 1],
+                "Strand": ["-", "+", "+"],
+            }
+        )
+    )
+
+    assert _rows(gr.complement_ranges(use_strand=True), ["Chromosome", "Start", "End", "Strand"]) == [
+        ("chr01", 1, 2, "+")
+    ]
+
+
+def test_result_does_not_depend_on_input_row_order() -> None:
+    base = [("chr01", 0, 1, "-"), ("chr01", 2, 3, "+"), ("chr01", 0, 1, "+")]
+
+    results = set()
+    for permutation in itertools.permutations(range(len(base))):
+        rows = [base[index] for index in permutation]
+        gr = pr.PyRanges(
+            pd.DataFrame(
+                {
+                    "Chromosome": [row[0] for row in rows],
+                    "Start": [row[1] for row in rows],
+                    "End": [row[2] for row in rows],
+                    "Strand": [row[3] for row in rows],
+                }
+            )
+        )
+        results.add(tuple(_rows(gr.complement_ranges(use_strand=True), ["Start", "End", "Strand"])))
+
+    assert results == {((1, 2, "+"),)}
+
+
+def test_categorical_group_columns_keep_their_dtype() -> None:
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": pd.Categorical(["chr2", "chr2", "chr1", "chr1"]),
+                "Start": [0, 20, 0, 10],
+                "End": [1, 21, 1, 11],
+                "Strand": pd.Categorical(["+", "+", "+", "+"]),
+            }
+        )
+    )
+
+    result = gr.complement_ranges(use_strand=True)
+
+    assert result["Chromosome"].dtype == "category"
+    assert result["Strand"].dtype == "category"
+    assert _rows(result, ["Chromosome", "Start", "End", "Strand"]) == [
+        ("chr1", 1, 10, "+"),
+        ("chr2", 1, 20, "+"),
+    ]
+
+
+def test_grouped_complement_with_chromsizes_labels_each_group() -> None:
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr1"] * 4,
+                "Start": [2, 10, 20, 40],
+                "End": [5, 18, 30, 46],
+                "ID": ["a", "a", "b", "b"],
+            }
+        )
+    )
+
+    result = gr.complement_ranges(
+        group_by="ID",
+        group_sizes_col="ID",
+        chromsizes={"a": 22, "b": 100},
+        include_first_interval=True,
+    )
+
+    assert _rows(result, ["Chromosome", "Start", "End", "ID"]) == [
+        ("chr1", 0, 2, "a"),
+        ("chr1", 0, 20, "b"),
+        ("chr1", 5, 10, "a"),
+        ("chr1", 18, 22, "a"),
+        ("chr1", 30, 40, "b"),
+        ("chr1", 46, 100, "b"),
+    ]

--- a/tests/unit/test_loci_open_bounds.py
+++ b/tests/unit/test_loci_open_bounds.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for open-ended ``loci`` slice bounds.
+
+An omitted bound in ``gr.loci[start:end]`` leaves that side of the window
+open. The upper bound already used an infinite limit, but the lower bound
+defaulted to ``-1``, which silently dropped intervals lying entirely below
+that coordinate.
+"""
+
+import numpy as np
+import pandas as pd
+
+import pyranges1 as pr
+
+
+def _spans(gr) -> list[tuple[int, int]]:
+    return sorted(zip(gr.Start.tolist(), gr.End.tolist(), strict=True))
+
+
+def _negative_ranges() -> "pr.PyRanges":
+    """Intervals below, across, and above the origin."""
+    return pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr1"] * 3,
+                "Start": [-100, -20, 5],
+                "End": [-50, 10, 30],
+                "Strand": ["+", "-", "+"],
+            },
+        ),
+    )
+
+
+def test_omitted_start_selects_intervals_below_the_origin() -> None:
+    gr = _negative_ranges()
+    # Every interval starting before 1, including the wholly negative one.
+    assert _spans(gr.loci[:1]) == [(-100, -50), (-20, 10)]
+
+
+def test_omitted_start_reaches_a_negative_upper_bound() -> None:
+    gr = _negative_ranges()
+    # A window lying entirely in negative coordinates.
+    assert _spans(gr.loci[:-60]) == [(-100, -50)]
+
+
+def test_omitted_end_is_unchanged_by_the_lower_bound_default() -> None:
+    gr = _negative_ranges()
+    assert _spans(gr.loci[-60:]) == [(-100, -50), (-20, 10), (5, 30)]
+
+
+def test_both_bounds_omitted_selects_everything() -> None:
+    gr = _negative_ranges()
+    assert _spans(gr.loci[:]) == [(-100, -50), (-20, 10), (5, 30)]
+
+
+def test_open_bounds_agree_with_an_explicit_infinite_window() -> None:
+    gr = _negative_ranges()
+    for key, explicit in (
+        (slice(None, 1), slice(-np.inf, 1)),
+        (slice(-60, None), slice(-60, np.inf)),
+        (slice(None, None), slice(-np.inf, np.inf)),
+    ):
+        assert _spans(gr.loci[key]) == _spans(gr.loci[explicit]), key
+
+
+def test_non_negative_coordinates_are_unaffected() -> None:
+    """The old lower default only differed for coordinates at or below -1."""
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr1"] * 3,
+                "Start": [0, 10, 20],
+                "End": [5, 15, 25],
+                "Strand": ["+", "-", "+"],
+            },
+        ),
+    )
+    assert _spans(gr.loci[:12]) == [(0, 5), (10, 15)]
+    assert _spans(gr.loci[12:]) == [(10, 15), (20, 25)]
+    assert _spans(gr.loci[:]) == [(0, 5), (10, 15), (20, 25)]
+
+
+def test_open_bounds_compose_with_chromosome_and_strand() -> None:
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr1", "chr1", "chr2"],
+                "Start": [-100, -20, -100],
+                "End": [-50, 10, -50],
+                "Strand": ["+", "-", "+"],
+            },
+        ),
+    )
+    assert _spans(gr.loci["chr1", :1]) == [(-100, -50), (-20, 10)]
+    assert _spans(gr.loci["chr1", "+", slice(None, 1)]) == [(-100, -50)]
+    assert _spans(gr.loci["+", :1]) == [(-100, -50), (-100, -50)]


### PR DESCRIPTION
Fixes #157.

## Summary

`complement_ranges` could return the wrong `Chromosome` and `Strand` — silently, with the answer depending only on the order of the input rows. In the worst case an entire chromosome disappeared from the result and its gap was relabelled as another chromosome.

The root cause is in the `ruranges` complement kernel, not here: its returned index was pinned to a hardcoded `0` for the group that sorts first, so whenever this frame's row 0 belonged to a different group, `df.take(idxs)` read that group's labels. Because the `by`-derived `Chromosome` overwrites the kernel's own `chrs`, both label columns could be corrupted.

That kernel bug is fixed in pyranges/ruranges-core#1, released as `ruranges` 0.1.5 (pyranges/ruranges#34). **Both must be merged and published before this one.**

## What this PR does

Raises the floor rather than working around the kernel:

* `pyproject.toml`: `ruranges>=0.1.4` → `ruranges>=0.1.5`
* `_ruranges.py`: `MIN_RURANGES_VERSION = "0.1.3"` → `"0.1.5"`

Both were lower bounds with no upper bound, so a user sitting on the buggy 0.1.4 satisfied the requirement and got silently wrong results. With the floor raised, an old kernel produces an explicit `ImportError` instead of a plausible-looking wrong answer.

I also prototyped fixing this locally — deriving the labels from `out_chrs`, the group key the kernel already returns correctly and which this code was discarding. It works against 0.1.4 and needs no ruranges release. I did not propose it here because it duplicates a fix that belongs upstream, adds an O(n) lookup where the original does an O(k) `take` (82.1 ms → 86.4 ms on 1M rows), and would leave `complement_ranges` depending on an index contract that has already been wrong once. Happy to switch if you would rather ship the fix without waiting on the release chain.

## Tests

Added `tests/unit/test_complement_ranges.py` — five regression tests covering behaviour, not internals, so they stay valid regardless of where the fix lands:

| test | asserts |
|---|---|
| `test_gaps_keep_their_own_chromosome_when_groups_are_not_in_ascending_order` | the chromosome-corruption case: two gaps keep `chr1` and `chr2` |
| `test_gap_is_labelled_with_the_strand_that_produced_it` | the `-` strand has no internal gap, so the gap is `+` |
| `test_result_does_not_depend_on_input_row_order` | identical result across all 6 row permutations |
| `test_categorical_group_columns_keep_their_dtype` | `category` dtype survives (a real trap: an earlier draft silently downgraded it to `str`, caught by `how_to_genomic_ops.rst`) |
| `test_grouped_complement_with_chromsizes_labels_each_group` | grouped complement with `chromsizes` and `include_first_interval` |

Verified in a clean virtualenv against a locally built `ruranges` 0.1.5:

* `pytest tests/unit/test_complement_ranges.py` — **5 passed**
* `pytest tests/unit` — **65 passed**
* `python tests/run_doctest_tutorial_howto.py` — **10 passed**
* `pytest --doctest-modules pyranges1` — **79 passed, 1 failed**; the failure is `PyRanges.to_bigwig`, which needs the optional `pyrle` package that is not installed in that environment, and fails identically on `master`

Against the current released `ruranges` 0.1.4 the three attribution tests fail, which is exactly the behaviour the floor now prevents.

CI will stay red on this PR until `ruranges` 0.1.5 is on PyPI.
