### PR TITLE
Bump version to 1.3.10

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+# 1.3.10 (27.07.26)
+- require `ruranges>=0.1.5`, which fixes `complement_ranges` attributing each gap to an arbitrary row's grouping columns (gh-157)
+- `loci` now leaves an omitted slice bound genuinely open; the lower bound was clamped to a finite value, so `gr.loci[:n]` silently dropped intervals lying entirely below it
+- remove `copy=False` from an `astype` call that failed pyright CI; add tox `[gh]` section
+
 # 1.3.9 (30.05.26)
 - fix `join_overlaps` duplicating rows in `left`/`outer` joins when the input index did not start at 0
 - preserve the input index in `join_overlaps` output (self for inner/left/outer, other for right), consistent with `overlap`/`nearest_ranges`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges1"
-version = "1.3.9"
+version = "1.3.10"
 description = "GenomicRanges for Python."
 requires-python = ">=3.12.0"
 readme = "README.md"


### PR DESCRIPTION
Version-only release of the two fixes already merged since 1.3.9.

## Changes

- `pyproject.toml`: `1.3.9` → `1.3.10`
- `CHANGELOG.txt`: entry for 1.3.10

No source changes.

## What 1.3.10 releases

| PR | Fix |
| --- | --- |
| #158 | `ruranges>=0.1.5` floor, fixing `complement_ranges` attributing each gap to an arbitrary row's grouping columns (gh-157) |
| #158 | `loci` leaves an omitted slice bound genuinely open — the lower bound was clamped to a finite value, so `gr.loci[:n]` silently dropped intervals lying entirely below it |
| — | `astype(copy=False)` removal that failed pyright CI, plus a tox `[gh]` section |

The changelog entry is included because this repo pairs every version bump with one; happy to drop it if you want the PR to touch `pyproject.toml` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
