### PR TITLE
Keep divided BigWig tracks that reduce to a single run

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 # 1.3.11 (30.07.26)
 - fix `to_bigwig(divide=True)` silently dropping any chromosome whose divided track reduces to a single run; `pyrle`'s `defragment` zeroes the value in that case and `to_ranges` then discards it as uncovered, so e.g. a one-interval frame with `Value=2` over coverage 1 returned no rows instead of log2(2) (gh-160)
 - remove the dead `new_pyrles` accumulator in the same branch, which was built and discarded, and the redundant per-track `defragment()` call whose return value was thrown away
+- removed the only doctest example showcasing a negative slack value, which isn't supported
 
 # 1.3.10 (27.07.26)
 - require `ruranges>=0.1.5`, which fixes `complement_ranges` attributing each gap to an arbitrary row's grouping columns (gh-157)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+# 1.3.11 (30.07.26)
+- fix `to_bigwig(divide=True)` silently dropping any chromosome whose divided track reduces to a single run; `pyrle`'s `defragment` zeroes the value in that case and `to_ranges` then discards it as uncovered, so e.g. a one-interval frame with `Value=2` over coverage 1 returned no rows instead of log2(2) (gh-160)
+- remove the dead `new_pyrles` accumulator in the same branch, which was built and discarded, and the redundant per-track `defragment()` call whose return value was thrown away
+
 # 1.3.10 (27.07.26)
 - require `ruranges>=0.1.5`, which fixes `complement_ranges` attributing each gap to an arbitrary row's grouping columns (gh-157)
 - `loci` now leaves an omitted slice bound genuinely open; the lower bound was clamped to a finite value, so `gr.loci[:n]` silently dropped intervals lying entirely below it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges1"
-version = "1.3.10"
+version = "1.3.11"
 description = "GenomicRanges for Python."
 requires-python = ">=3.12.0"
 readme = "README.md"

--- a/pyranges1/core/out.py
+++ b/pyranges1/core/out.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,9 @@ from pandas.core.frame import DataFrame
 from pyranges1.core.names import BIGWIG_SCORE_COL, CHROM_COL, END_COL, PANDAS_COMPRESSION_TYPE, START_COL
 from pyranges1.core.pyranges_helpers import ensure_pyranges
 from pyranges1.core.pyranges_main import PyRanges
+
+if TYPE_CHECKING:
+    from pyrle import RleDict  # type: ignore[import]
 
 GTF_COLUMNS_TO_PYRANGES = {
     "seqname": "Chromosome",
@@ -161,6 +164,37 @@ def _to_bed(
     )
 
 
+def _merged_runs(rles: "RleDict") -> "RleDict":
+    """Merge consecutive runs holding the same value, in every track.
+
+    This is what ``pyrle``'s ``defragment`` is for, but that implementation
+    zeroes the value whenever the merged result collapses to a single run --
+    ``Rle([5], [3.0]).defragment()`` yields a value of ``0.0``. Since
+    ``to_ranges`` then discards zero-valued runs as uncovered, relying on it
+    silently deletes any track that reduces to one run.
+
+    ``NaN`` is treated as equal to ``NaN`` so that adjacent undefined runs
+    merge, matching ``defragment``'s behaviour on inputs where it is correct.
+    """
+    from pyrle import Rle, RleDict
+
+    merged = {}
+    for chromosome, rle in rles.items():
+        runs = np.asarray(rle.runs)
+        values = np.asarray(rle.values, dtype=float)
+        if values.size <= 1:
+            merged[chromosome] = Rle(runs.copy(), values.copy())
+            continue
+        previous, current = values[:-1], values[1:]
+        same = (current == previous) | (np.isnan(current) & np.isnan(previous))
+        starts = np.concatenate(([0], np.flatnonzero(~same) + 1))
+        merged_values = values[starts]
+        # `defragment` normalises negative zero; keep that.
+        merged_values[merged_values == 0] = 0.0
+        merged[chromosome] = Rle(np.add.reduceat(runs, starts), merged_values)
+    return RleDict(merged)
+
+
 def _to_bigwig(
     self: PyRanges,
     path: None,
@@ -185,16 +219,12 @@ def _to_bigwig(
         rles = self.to_rle(rpm=rpm, strand=False, value_col=value_col)
         df = rles.to_ranges()
     else:
-        df = self.to_rle(rpm=rpm, strand=False, value_col=value_col)
-        divide_by = self.to_rle(rpm=rpm, strand=False)
-        c = df / divide_by
-        new_pyrles = {}
-        for k, v in c.items():
-            v.values = np.log2(v.values)
-            v.defragment()
-            new_pyrles[k] = v
-
-        df = c.defragment().to_ranges()
+        numerator = self.to_rle(rpm=rpm, strand=False, value_col=value_col)
+        denominator = self.to_rle(rpm=rpm, strand=False)
+        ratio = numerator / denominator
+        for rle in ratio.values():
+            rle.values = np.log2(rle.values)
+        df = _merged_runs(ratio).to_ranges()
     gr = ensure_pyranges(df)
     unique_chromosomes = gr.chromosomes
 

--- a/tests/unit/out/test_out.py
+++ b/tests/unit/out/test_out.py
@@ -1,3 +1,8 @@
+import pandas as pd
+
+import pyranges1 as pr
+
+
 def test_write_bed(chip_10, tmp_path) -> None:
     outfile = tmp_path / "deleteme.bed"
     chip_10.to_bed(outfile)
@@ -30,3 +35,69 @@ def test_write_bigwig(chip_10, tmp_path, chromsizes) -> None:
         chip_10.to_bigwig(outpath, chromosome_sizes=chromsizes)
     except SystemExit:
         pass
+
+
+def test_to_bigwig_divide_keeps_single_run_tracks() -> None:
+    """A divided track that reduces to one run must survive.
+
+    ``pyrle``'s ``defragment`` zeroes the value whenever the merged result is a
+    single run, and ``to_ranges`` then discards zero-valued runs as uncovered,
+    so such a track disappeared entirely (gh-160).
+    """
+    import numpy as np
+
+    # One interval, value 2 over coverage 1: log2(2 / 1) == 1.0.
+    single = pr.PyRanges(
+        pd.DataFrame({"Chromosome": ["chr1"], "Start": [0], "End": [4], "Value": [2]}),
+    )
+    result = single.to_bigwig(
+        None, chromosome_sizes={"chr1": 10}, value_col="Value", divide=True, rpm=False, return_data=True
+    )
+    assert len(result) == 1
+    assert result["Score"].tolist() == [1.0]
+
+    # Two chromosomes, one of which reduces to a single run: neither may be lost.
+    pair = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr2", "chr1"],
+                "Start": [0, 1],
+                "End": [1, 2],
+                "Value": [2, 1],
+            },
+        ),
+    )
+    both = pair.to_bigwig(
+        None,
+        chromosome_sizes={"chr1": 22, "chr2": 21},
+        value_col="Value",
+        divide=True,
+        rpm=False,
+        return_data=True,
+    )
+    assert sorted(both["Chromosome"].astype(str).tolist()) == ["chr1", "chr2"]
+    scores = dict(zip(both["Chromosome"].astype(str), both["Score"], strict=True))
+    assert scores["chr2"] == 1.0
+    # chr1 is uncovered where its value track is defined, so the ratio is undefined.
+    assert np.isnan(scores["chr1"])
+
+
+def test_to_bigwig_divide_merges_adjacent_equal_runs() -> None:
+    """Consecutive runs with the same ratio still collapse into one interval."""
+    gr = pr.PyRanges(
+        pd.DataFrame(
+            {
+                "Chromosome": ["chr1", "chr1"],
+                "Start": [0, 4],
+                "End": [4, 8],
+                "Value": [2, 2],
+            },
+        ),
+    )
+    result = gr.to_bigwig(
+        None, chromosome_sizes={"chr1": 20}, value_col="Value", divide=True, rpm=False, return_data=True
+    )
+    assert len(result) == 1
+    assert result["Start"].tolist() == [0]
+    assert result["End"].tolist() == [8]
+    assert result["Score"].tolist() == [1.0]


### PR DESCRIPTION
# Keep divided BigWig tracks that reduce to a single run

## The bug

`to_bigwig(divide=True)` silently drops any chromosome whose divided track
merges down to a single run. No error, no warning — the track is simply absent
from the output and from the written BigWig.

```python
import pandas as pd, pyranges1 as pr

gr = pr.PyRanges(pd.DataFrame(
    {"Chromosome": ["chr1"], "Start": [0], "End": [4], "Value": [2]}))

gr.to_bigwig(None, chromosome_sizes={"chr1": 10},
             value_col="Value", divide=True, rpm=False, return_data=True)
```

Before: an empty result. After: one row, `chr1 0-4` with score `1.0`, which is
`log2(2 / 1)`.

With more than one chromosome it is worse, because the loss is partial and so
easier to miss:

```python
gr = pr.PyRanges(pd.DataFrame({
    "Chromosome": ["chr2", "chr1"],
    "Start": [0, 1], "End": [1, 2], "Value": [2, 1]}))

gr.to_bigwig(None, chromosome_sizes={"chr1": 22, "chr2": 21},
             value_col="Value", divide=True, rpm=False, return_data=True)
```

Before: only `chr1 0-1 NaN`. After: that row plus `chr2 0-1 1.0`.

## Why it happens

Not in this package's arithmetic, which is correct. The divide branch ends with

```python
df = c.defragment().to_ranges()
```

and `pyrle`'s `Rle.defragment` zeroes the value whenever the merged result
collapses to exactly one run:

```python
>>> from pyrle import Rle
>>> import numpy as np
>>> Rle(np.array([5]), np.array([3.0])).defragment().values
array([0.])
```

`to_ranges` then treats a zero-valued run as uncovered and discards it, so a
whole track disappears with nothing to indicate it. Multi-run results are
unaffected, which is why this went unnoticed: it only bites when a track is
uniform.

This PR merges consecutive equal runs locally instead of routing through
`defragment`. `NaN` is treated as equal to `NaN` so adjacent undefined runs
still collapse — matching `defragment`'s behaviour on the inputs where it is
correct — and negative zero is still normalised.

The root cause is a `pyrle` bug, fixed separately in
[pyranges/pyrle#15](https://github.com/pyranges/pyrle/pull/15): its
`_remove_dupes` returns typed memoryviews on its single-element path but numpy
arrays everywhere else, and `defragment`'s `values[values == -0] = 0` therefore
compares the object rather than its elements, producing a scalar `False` that
indexes element 0 instead of masking.

That fix alone repairs this writer with `pyranges1` unchanged, so this PR is not
required to close the bug. It is still worth landing on its own terms:

- it makes `to_bigwig` correct against any installed `pyrle`, including versions
  released before that fix, which matters because `pyrle` is a runtime
  dependency resolved at install time;
- it removes dead code in the same branch (below);
- it does not depend on a `pyrle` release, which has not happened yet.

Two dead statements in the same branch are removed with it: `new_pyrles` was
built and never read, and the per-track `defragment()` call threw away its
return value, `defragment` being a pure function.

## How it was found

Comparing this writer against an independent implementation over randomized
inputs. The two agreed exactly on every input where `pyranges1` kept the
track — including `log2(3) = 1.5849625` — and differed only where it dropped
one, which is what identified `pyranges1` rather than the other implementation
as the incorrect side.

## Tests

Two regression tests in `tests/unit/out/test_out.py`:

- `test_to_bigwig_divide_keeps_single_run_tracks` — the single-chromosome case
  that returned nothing, and the two-chromosome case that lost one track.
- `test_to_bigwig_divide_merges_adjacent_equal_runs` — adjacent runs with the
  same ratio still collapse into one interval, so the merging behaviour is not
  lost in the process of fixing the value.

`tests/` passes (74 passed). `tests/test_parallelism.py` fails on this machine
both with and without this change, for unrelated reasons, so it was excluded.

`ruff check pyranges1/core/out.py` is clean.

## Compatibility

No API change. Output changes only for inputs that were previously losing data.
Version bumped to 1.3.11 with a changelog entry.
