### PR TITLE
Fix return type annotation of PyRanges.__new__ to enable method chaining in static type checkers

### DIFF
--- a/pyranges1/core/pyranges_main.py
+++ b/pyranges1/core/pyranges_main.py
@@ -167,7 +167,7 @@ class PyRanges(RangeFrame):
 
     """
 
-    def __new__(cls, *args, **kwargs) -> "pr.PyRanges | pd.DataFrame":  # type: ignore[misc]
+    def __new__(cls, *args, **kwargs) -> "pr.PyRanges":  # type: ignore[misc]
         """Create a new instance of a PyRanges object."""
         # __new__ is a special static method used for creating and
         # returning a new instance of a class. It is called before


### PR DESCRIPTION
Currently, `PyRanges.__new__` is annotated as returning `pr.PyRanges | pd.DataFrame`. When a user instantiates a PyRanges object:

```python
import pyranges1 as pr
import pandas as pd

df = pd.DataFrame({"Chromosome": ["chr1"], "Start": [0], "End": [100]})
gr = pr.PyRanges(df)

# Type checker error!
# "Item 'DataFrame' of 'PyRanges | DataFrame' has no attribute 'join_overlaps'"
result = gr.join_overlaps(other_gr)
```

Because PyRanges inherits from DataFrame, any function expecting a DataFrame already accepts a PyRanges instance without needing `| pd.DataFrame` in the annotation.