### PR TITLE
Build frames from the manager instead of rebuilding them

### DIFF
--- a/pyranges1/core/pyranges_main.py
+++ b/pyranges1/core/pyranges_main.py
@@ -168,6 +168,10 @@ class PyRanges(RangeFrame):
 
     """
 
+    # built on first use by the loci property: pandas builds frames from a manager without
+    # ever calling __init__, so this cannot be set there alone.
+    _loci: "LociGetter | None" = None
+
     def __new__(cls, *args, **kwargs) -> "pr.PyRanges":  # type: ignore[misc]
         """Create a new instance of a PyRanges object."""
         # __new__ is a special static method used for creating and
@@ -184,10 +188,18 @@ class PyRanges(RangeFrame):
         if not args and "data" not in kwargs:
             return super().__new__(cls)
 
-        df = pd.DataFrame(kwargs.get("data") if "data" in kwargs else args[0])
-        missing_any_required_columns = not set(GENOME_LOC_COLS).issubset({*df.columns})
+        # pandas hands us a whole DataFrame every time it rebuilds a frame internally, so read
+        # the columns off it rather than building a second frame just to look at them; a call
+        # that names the columns on the way in still has to be built before they can be read.
+        data = kwargs["data"] if "data" in kwargs else args[0]
+        if isinstance(data, pd.DataFrame) and "columns" not in kwargs:
+            columns = data.columns
+        else:
+            columns = pd.DataFrame(*args, **kwargs).columns
+
+        missing_any_required_columns = not set(GENOME_LOC_COLS).issubset({*columns})
         if missing_any_required_columns:
-            missing = sorted(set(GENOME_LOC_COLS) - set(df.columns))
+            missing = sorted(set(GENOME_LOC_COLS) - set(columns))
             msg = f"Cannot construct PyRanges: missing required column(s) {missing}."
             raise ValueError(msg)
 
@@ -204,11 +216,22 @@ class PyRanges(RangeFrame):
 
         super().__init__(*args, **kwargs)
 
-        self._loci = LociGetter(self)
-
     @property
     def _constructor(self) -> Callable[..., "pr.PyRanges | pd.DataFrame"]:
         return self._constructor_with_fallback
+
+    def _constructor_from_mgr(self, mgr, axes) -> "pr.PyRanges | pd.DataFrame":
+        """Build a frame from a block manager, which is how pandas rebuilds one internally.
+
+        pandas' own version routes a rebuild through PyRanges(DataFrame(...)), building and
+        validating two more frames on the way; from the manager we can do neither. A frame
+        that lost a required column cannot be a PyRanges, so it comes back a plain DataFrame.
+        """
+        # _from_mgr is pandas' own way of doing this (see DataFrame._constructor_from_mgr);
+        # pandas-stubs does not declare it, hence the ignores.
+        if not set(GENOME_LOC_COLS).issubset({*axes[0]}):
+            return pd.DataFrame._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
+        return type(self)._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
 
     @classmethod
     def _constructor_with_fallback(cls, *args, **kwargs) -> "pr.PyRanges | pd.DataFrame":
@@ -427,6 +450,8 @@ class PyRanges(RangeFrame):
         TypeError: The loci accessor does not accept a list. If you meant to retrieve columns, use get_with_loc_columns instead.
 
         """
+        if self._loci is None:
+            self._loci = LociGetter(self)
         return self._loci
 
     def _chrom_and_strand_info(self) -> str:

--- a/pyranges1/core/pyranges_main.py
+++ b/pyranges1/core/pyranges_main.py
@@ -168,6 +168,10 @@ class PyRanges(RangeFrame):
 
     """
 
+    # a frame that loses one of these is no longer a PyRanges: RangeFrame._constructor_from_mgr
+    # rebuilds it as a plain DataFrame.
+    _required_columns: frozenset[str] = frozenset(GENOME_LOC_COLS)
+
     # built on first use by the loci property: pandas builds frames from a manager without
     # ever calling __init__, so this cannot be set there alone.
     _loci: "LociGetter | None" = None
@@ -219,19 +223,6 @@ class PyRanges(RangeFrame):
     @property
     def _constructor(self) -> Callable[..., "pr.PyRanges | pd.DataFrame"]:
         return self._constructor_with_fallback
-
-    def _constructor_from_mgr(self, mgr, axes) -> "pr.PyRanges | pd.DataFrame":
-        """Build a frame from a block manager, which is how pandas rebuilds one internally.
-
-        pandas' own version routes a rebuild through PyRanges(DataFrame(...)), building and
-        validating two more frames on the way; from the manager we can do neither. A frame
-        that lost a required column cannot be a PyRanges, so it comes back a plain DataFrame.
-        """
-        # _from_mgr is pandas' own way of doing this (see DataFrame._constructor_from_mgr);
-        # pandas-stubs does not declare it, hence the ignores.
-        if not set(GENOME_LOC_COLS).issubset({*axes[0]}):
-            return pd.DataFrame._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
-        return type(self)._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
 
     @classmethod
     def _constructor_with_fallback(cls, *args, **kwargs) -> "pr.PyRanges | pd.DataFrame":
@@ -799,7 +790,8 @@ class PyRanges(RangeFrame):
 
     def copy(self, *args, **kwargs) -> "pr.PyRanges":
         """Return a copy of the PyRanges."""
-        return ensure_pyranges(super().copy(*args, **kwargs))
+        # a copy keeps every column, so pandas hands this straight back as our own class
+        return self._rebuild_as_self(super().copy(*args, **kwargs))
 
     def _count_overlaps(
         self,

--- a/pyranges1/range_frame/range_frame.py
+++ b/pyranges1/range_frame/range_frame.py
@@ -61,8 +61,24 @@ class RangeFrame(pd.DataFrame):
     A table with Start and End columns. Parent class of PyRanges. Subclass of pandas DataFrame.
     """
 
+    # a frame without these is not a RangeFrame, so pandas rebuilds it as a plain DataFrame.
+    # PyRanges requires Chromosome as well.
+    _required_columns: frozenset[str] = frozenset(RANGE_COLS)
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
+    def _constructor_from_mgr(self, mgr, axes) -> "RangeFrame | pd.DataFrame":
+        """Build a frame from a block manager, which is how pandas rebuilds one internally.
+
+        pandas' own version routes a rebuild through RangeFrame(DataFrame(...)), building and
+        validating two more frames on the way; from the manager we can do neither.
+        """
+        # _from_mgr is pandas' own way of doing this (see DataFrame._constructor_from_mgr);
+        # pandas-stubs does not declare it, hence the ignores.
+        if not self._required_columns.issubset(axes[0]):
+            return pd.DataFrame._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
+        return type(self)._from_mgr(mgr, axes=axes)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
 
     def __str__(
         self,
@@ -856,7 +872,8 @@ class RangeFrame(pd.DataFrame):
         return self
 
     def copy(self, *args, **kwargs) -> "RangeFrame":  # pyright: ignore[reportIncompatibleMethodOverride]  # noqa: D102
-        return _mypy_ensure_rangeframe(super().copy(*args, **kwargs))
+        # a copy keeps every column, so pandas hands this straight back as our own class
+        return self._rebuild_as_self(super().copy(*args, **kwargs))
 
     @classmethod
     def _constructor_with_fallback(cls, *args, **kwargs) -> "RangeFrame | pd.DataFrame":
@@ -876,6 +893,8 @@ class RangeFrame(pd.DataFrame):
         # lost a column we require; rebuilding either one costs two more frames and buys
         # nothing.
         if result is None or type(result) is type(self):
+            return result
+        if not self._required_columns.issubset(result.columns):
             return result
         return self._constructor_with_fallback(result)
 

--- a/pyranges1/range_frame/range_frame.py
+++ b/pyranges1/range_frame/range_frame.py
@@ -870,15 +870,24 @@ class RangeFrame(pd.DataFrame):
         """
         return cls(*args, **kwargs)
 
+    def _rebuild_as_self(self, result: Any) -> Any:
+        """Return result as our own class, building it only if pandas did not already."""
+        # _constructor_from_mgr already hands back our class, or a DataFrame when the frame
+        # lost a column we require; rebuilding either one costs two more frames and buys
+        # nothing.
+        if result is None or type(result) is type(self):
+            return result
+        return self._constructor_with_fallback(result)
+
     def drop(self, *args, **kwargs) -> "RangeFrame | pd.DataFrame | None":  # type: ignore[override]  # noqa: D102
-        return self._constructor_with_fallback(super().drop(*args, **kwargs))
+        return self._rebuild_as_self(super().drop(*args, **kwargs))
 
     def drop_and_return(self, *args: Any, **kwargs: Any) -> "RangeFrame | pd.DataFrame":  # noqa: D102
         kwargs["inplace"] = False
-        return self._constructor_with_fallback(super().drop(*args, **kwargs))
+        return self._rebuild_as_self(super().drop(*args, **kwargs))
 
     def reindex(self, *args, **kwargs) -> "RangeFrame | pd.DataFrame":  # noqa: D102
-        return self._constructor_with_fallback(super().reindex(*args, **kwargs))
+        return self._rebuild_as_self(super().reindex(*args, **kwargs))
 
 
 def _mypy_ensure_rangeframe(r: pd.DataFrame) -> "RangeFrame":

--- a/tests/unit/test_pandas_overrides.py
+++ b/tests/unit/test_pandas_overrides.py
@@ -1,5 +1,7 @@
 """Test that overriden pandas methods work and return PyRanges objects."""
 
+import pickle
+
 import pandas as pd
 import pandas.core.groupby
 import pytest
@@ -261,3 +263,28 @@ def test_range_frame_never_degrades() -> None:
     assert type(rf.drop("Val", axis=1)) is pr.RangeFrame
     assert type(rf.drop_and_return("Val", axis=1)) is pr.RangeFrame
     assert type(rf.reindex(columns=["Start"])) is pr.RangeFrame
+
+
+def test_rebuilt_frames_are_pyranges(gr) -> None:
+    # pandas builds these from a block manager, without going through PyRanges(...)
+    assert type(gr.head(1)) is pr.PyRanges
+    assert type(gr[gr.Start >= 0]) is pr.PyRanges
+    assert type(gr.copy()) is pr.PyRanges
+    assert type(gr.reset_index(drop=True)) is pr.PyRanges
+
+
+def test_loci_survives_a_rebuild(gr) -> None:
+    # the loci accessor is built on demand, because pandas rebuilds frames without __init__
+    assert len(gr.head(1).loci["chr1"]) == 1
+    assert len(gr.copy().loci["chr1"]) == 2
+
+
+def test_loci_survives_a_pickle_roundtrip(gr) -> None:
+    unpickled = pickle.loads(pickle.dumps(gr))  # noqa: S301
+    assert type(unpickled) is pr.PyRanges
+    assert len(unpickled.loci["chr1"]) == 2
+
+
+def test_data_can_be_passed_by_keyword() -> None:
+    df = pd.DataFrame({"Chromosome": ["chr1"], "Start": [0], "End": [40]})
+    assert type(pr.PyRanges(data=df)) is pr.PyRanges

--- a/tests/unit/test_pandas_overrides.py
+++ b/tests/unit/test_pandas_overrides.py
@@ -257,12 +257,20 @@ def test_reindex(gr) -> None:
     assert type(gr.reindex(columns=["Start", "End"])) is pd.DataFrame
 
 
-def test_range_frame_never_degrades() -> None:
-    # a RangeFrame requires no columns, so these always stay a RangeFrame
+def test_rebuilt_frames_are_rangeframes() -> None:
     rf = pr.RangeFrame({"Start": [0, 10], "End": [40, 20], "Val": [50, 30]})
     assert type(rf.drop("Val", axis=1)) is pr.RangeFrame
     assert type(rf.drop_and_return("Val", axis=1)) is pr.RangeFrame
-    assert type(rf.reindex(columns=["Start"])) is pr.RangeFrame
+    assert type(rf.reindex(columns=["Start", "End"])) is pr.RangeFrame
+    assert type(rf.head(1)) is pr.RangeFrame
+    assert type(rf[rf.Start >= 0]) is pr.RangeFrame
+    assert type(rf.copy()) is pr.RangeFrame
+    assert type(rf[["Start", "End"]]) is pr.RangeFrame
+
+    # ... and a frame without Start and End is not one, since none of its methods would work
+    assert type(rf.reindex(columns=["Start"])) is pd.DataFrame
+    assert type(rf.drop("Start", axis=1)) is pd.DataFrame
+    assert type(rf[["Val"]]) is pd.DataFrame
 
 
 def test_rebuilt_frames_are_pyranges(gr) -> None:


### PR DESCRIPTION
**Stacked on #171 — this PR targets `fix_new`, not `master`.** It will be retargeted to `master` once #171 merges. The diff here is only the two commits on top of that branch.

Every pandas operation that returns a new frame rebuilds it through `_constructor`, and PyRanges makes that path expensive. A single `gr.drop(columns=["X"])` costs **four DataFrame constructions and eight manager copies**, where one of each will do:

1. pandas builds the result frame from the block manager it just produced;
2. `PyRanges.__new__` builds a second one, purely to look at its columns;
3. `PyRanges.__init__` builds a third by handing that frame to `DataFrame.__init__`;
4. `RangeFrame.drop` builds a fourth, wrapping the result pandas had already rebuilt as a PyRanges.

None of this scales with the data, so it is the same tax on a thousand rows as on a hundred million — it just stops being visible when there is real work to hide behind.

## What changed

**`_constructor_from_mgr` on RangeFrame.** This is the hook pandas calls when it has a block manager and needs a frame of the caller's class. Its default for a subclass routes through `PyRanges(DataFrame(...))`; the manager already carries the column index in `axes[0]`, so the required-column check needs no frame at all and the result can be built straight from the manager. Both classes share one implementation and declare what they cannot do without:

```python
class RangeFrame(pd.DataFrame):
    _required_columns: frozenset[str] = frozenset(RANGE_COLS)        # Start, End

class PyRanges(RangeFrame):
    _required_columns: frozenset[str] = frozenset(GENOME_LOC_COLS)   # + Chromosome
```

Keep the class while the frame still has those columns, hand back a plain DataFrame when it does not — the rule #171 established for PyRanges, now written once and applied to both.

**`__new__` stops building a frame to read columns.** pandas hands it a whole DataFrame on every rebuild, so the columns can be read off that one.

**`drop`, `drop_and_return`, `reindex` and `copy` return what pandas built.** After the above, pandas already hands back a frame of the right class, or a DataFrame when the frame lost a required column. Rebuilding either costs two more frames and buys nothing. `copy` matters more than it looks, because pandas implements `head` as `iloc[:n].copy()`.

**The `loci` accessor is built on first use.** Building from a manager never calls `__init__`, so `_loci` cannot be set there alone.

## Benchmarks

Microseconds per call at 10^6 rows, median of three interleaved rounds, pandas 3.0.5 on Python 3.13. Verified flat at 10^7 and 10^8 — `PyRanges.head` is 17.4 / 17.6 / 17.7 µs across the three sizes, because none of this is proportional to the data.

| operation | master | #171 | this PR | vs master |
|---|---|---|---|---|
| `PyRanges.head` | 108.0 | 133.9 | **17.4** | 6.2× |
| `PyRanges.reset_index` | 72.9 | 84.8 | **9.3** | 7.8× |
| `PyRanges.reindex` | 106.1 | 129.4 | **44.2** | 2.4× |
| `PyRanges.drop` | 115.7 | 141.0 | **55.1** | 2.1× |
| `PyRanges(df)` | 26.2 | 26.2 | **12.0** | 2.2× |
| `PyRanges.assign` | 690.0 | 667.5 | **482.5** | 1.4× |
| `PyRanges.astype` | 660.7 | 672.5 | **595.0** | 1.1× |
| `RangeFrame.drop` | 71.4 | 72.6 | **51.8** | 1.4× |
| `RangeFrame.reindex` | 61.1 | 63.1 | **41.5** | 1.5× |
| `RangeFrame.head` | 19.3 | 19.8 | **12.5** | 1.5× |
| `RangeFrame[cols]` | 85.9 | 87.1 | **77.9** | 1.1× |

**On the middle column:** #171 moves the degrade-to-DataFrame decision into `_constructor_with_fallback`, which builds a DataFrame to inspect its columns on every internal rebuild, costing ~22% on these operations. That is what this PR removes, by making the same decision from `axes[0]` without building anything. Merged together, the two land about twice as fast as today's master.

Operations whose cost is data movement — `copy`, boolean masking — are unchanged. A caveat on measuring those: in a tight loop that discards each result, the allocator penalises whichever variant allocates fewer intermediate objects, and that artifact is larger than the effect being measured; it shows in both directions depending on loop shape. Timed single-shot in fresh processes at 10^7 rows, a boolean mask is 57.3 ms on master and 56.2 ms here; at 10^8 rows every variant lands within 1% of the others (581.8 vs 581.9 ms).

## Behaviour changes

**RangeFrame now survives `head`, slicing, masking and `copy`.** pandas 2 rebuilt a subclassed frame as the subclass; pandas 3 rebuilds it as a plain DataFrame unless `_constructor` says otherwise, so `rf.head()` and `rf[cols]` had quietly started returning DataFrames while `rf.drop()` still returned a RangeFrame. They agree again.

**Dropping `Start` or `End` from a RangeFrame now yields a DataFrame.** A RangeFrame without them cannot even be printed — `repr` raises `KeyError` — yet `rf.drop("Start")` built one anyway. It now degrades, exactly as `gr.drop("Chromosome")` does. This is why `test_range_frame_never_degrades` from #171 is renamed and extended here: `rf.reindex(columns=["Start"])` is a DataFrame now, since a frame without `End` is not a RangeFrame.

## Fixed along the way

- `.loci` raised `AttributeError` on any PyRanges that came back from `pickle`, because `_loci` was only ever set in `__init__`, which unpickling skips.
- `pr.PyRanges(array, columns=[...])` silently returned a column-less DataFrame, because `__new__` checked the columns of a frame built without them.

## Risks worth knowing

**`_constructor_from_mgr` and `_from_mgr` are pandas internals** (both present since 2.1). The risk is asymmetric: if `_constructor_from_mgr` ever disappears, pandas simply stops calling our override and `_constructor` still handles everything; if `_from_mgr` disappears, the hook raises. pandas' own `_constructor_from_mgr` carries a shim for GeoDataFrame, so subclasses overriding this hook is an acknowledged pattern. A test asserting both attributes exist would turn a future pandas bump into a CI failure rather than a user-visible one — happy to add it if you want the belt and braces.

**`__init__` no longer runs when pandas rebuilds a frame.** This is the maintenance trap: anything added to `PyRanges.__init__` later will silently not happen for rebuilt frames. `_loci` was exactly that bug; `test_loci_survives_a_rebuild` guards it.

**Validation is by column name only** — the manager's dtypes are not inspected. Same as before, so nothing is lost, but the fast path adds no safety either.

**Subclasses of PyRanges are still not preserved end to end.** The hook itself now keeps them (`MyRanges(...).iloc[:1]` is a `MyRanges`), but 36 `ensure_pyranges(...)` call sites and `_constructor` hardcode `pr.PyRanges`. Unchanged from master; mentioned because the hook makes it look closer to working than it is.

**A few pandas paths still call `self._constructor(...)` directly** rather than through the manager hook. Of ~40 operations I instrumented, only `astype` does, and its overhead over plain pandas is already down from 162 µs to about 5 µs. A manager-based `_constructor` would take that last bit — measured at 4.7 µs per call — but it means handling every argument shape pandas uses at those call sites. Left out deliberately.

## Testing

pyright 0 errors, ruff format and check clean, 136 unit tests, 85 module doctests, 10 tutorial/how-to doctests — all with the versions CI pins (pandas 3.0.5, pandas-stubs 3.0.5.260730, pyright 1.1.406, ruranges 0.2.7).

New tests cover rebuilt frames keeping their class for both PyRanges and RangeFrame, degrading when a required column is gone, and `.loci` surviving both a rebuild and a pickle round-trip.
